### PR TITLE
Update Chase Freedom referral row: $200/$500-spend bonus wording

### DIFF
--- a/guides/referral.html
+++ b/guides/referral.html
@@ -117,11 +117,8 @@ layout: none
                             <span class="chinese">Freedom Unlimited / Flex 信用卡</span>
                         </td>
                         <td>
-                        <span class="english">Earn up to $500 cash back per year by referring friends for any
-                            participating Chase Freedom® card. That's $50 cash back for each friend who gets any
-                            participating Chase Freedom® card.</span>
-                        <span class="chinese">通过推荐朋友申请符合条件的 Chase Freedom® 卡，每年最高可获得 500 美元返现；每位成功获卡的朋友对应 50
-                            美元返现。</span>
+                        <span class="english">$200 bonus after $500 spend in the first 3 months; I also get a referral bonus when you're approved.</span>
+                        <span class="chinese">开卡后三个月内消费满 500 美元得 200 美元，你获批时我也能拿推荐奖励。</span>
                     </td>
                     <td>
                         <a href="https://www.referyourchasecard.com/18a/IU5092PSC4" target="_blank"


### PR DESCRIPTION
## Summary
- Updates the Chase Freedom row in `guides/referral.html` from "$500/year for referring, $50 per approved friend" to "$200 bonus after $500 spend in 3 months; referral bonus for me when approved."

## Note
This describes a **different, more specific offer** than the previous copy, and referral terms change often — please double-check the current Chase Freedom referral terms match this wording before merging.

## Test plan
- [ ] Confirm the new bonus terms are accurate against Chase's current referral offer
- [ ] Visually check `guides/referral.html` renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_0151YjTkrUtoVtTFxjEYy959)_