### PR TITLE
Fix Find box layout; add Issues nav link and AI Services link

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -44,6 +44,7 @@
     section_zh: "人工智能"
     links:
       - { url: "https://tech.utexas.edu/initiatives/artificial-intelligence", title: "UT AI", icon: "fad fa-robot", keywords: "UT AI, artificial intelligence, 人工智能" }
+      - { url: "https://aiservices.austin.utexas.edu/submit/", title: "AI Services", icon: "fad fa-paper-plane", keywords: "UT AI Services, AI request, submit AI request, AI tools, artificial intelligence services, 人工智能服务, 人工智能申请, 提交" }
       - { url: "http://tacite.ai/", title: "Tacite AI", icon: "fad fa-sparkles", keywords: "Tacite AI, 人工智能, 人工智能研究, 人工智能应用, 人工智能技术, 人工智能发展, 人工智能未来" }
       - { url: "https://memorybox.hawltechs.com/", title: "Memory Box", icon: "fad fa-brain", keywords: "AI Memory Box, AI memory, conversation storage, AI conversations, memory management, centralized memory layer, shared memory, AI productivity, 人工智能记忆, 对话存储, 记忆管理" }
 

--- a/_sass/nav.scss
+++ b/_sass/nav.scss
@@ -96,6 +96,28 @@
   vertical-align: middle;
 }
 
+/* Find-in-page group: input + button on the same line, like a Google search box */
+.u_find-form {
+  display: flex;
+  align-items: stretch;
+}
+.u_find-input {
+  float: none;
+  top: 0;
+  width: 280px;
+}
+.u_find-btn {
+  float: none;
+  top: 0;
+  width: 70px;
+  font-weight: bold;
+  border-left: 0;
+  background-color: #f8f9fa;
+  &:hover {
+    background-color: #eceff1;
+  }
+}
+
 /* 移动端搜索框组 */
 .um_nav-input-group {
   display: none;

--- a/index.html
+++ b/index.html
@@ -109,16 +109,11 @@ layout: none
                     <div class="um_nav-btn" onclick="search('bing', 'mobile')">Bing</div>
                     <div class="um_nav-btn" onclick="search('wolframalpha_mob', 'mobile')">Wolfram</div>
                 </div>
-                <div class="u_nav-input-group" style="position: absolute; left: 41%; transform: translateX(-50%); top: 10px; margin-left: 150px; z-index: 1;">
-                    <form id="find-form-pc">
-                        <input class="u_nav-input" id="find-in-page-input" placeholder="use whole word to find in this page..." style="width: 280px;">
-                        <input type="submit" hidden>
+                <div class="u_nav-input-group u_find-group" style="position: absolute; left: 41%; transform: translateX(-50%); top: 10px; margin-left: 150px; z-index: 1;">
+                    <form id="find-form-pc" class="u_find-form">
+                        <input class="u_nav-input u_find-input" id="find-in-page-input" placeholder="use whole word to find in this page...">
+                        <button type="submit" class="u_nav-btn u_find-btn">Find</button>
                     </form>
-                    <ul>
-                        <!-- <li class="u_nav-btn">
-                            <span style="font-weight: bold;">Find</span>
-                        </li> -->
-                    </ul>
                     <div id="no-results-message" class="no-results-nav" style="display: none;">
                         No results found. Try a different search term.
                     </div>
@@ -127,6 +122,7 @@ layout: none
                     <div class="u_nav-input-group" style="float: left; margin-right: 20px;">
                         <a href="https://github.com/ut01/ut01.github.io/fork" class="u_nav-link">Fork ut01</a>
                     </div>
+                    <a href="https://github.com/ut01/ut01.github.io/issues/new" class="u_nav-link" target="_blank" rel="noopener noreferrer">Issues</a>
                     <a href="#" class="u_nav-link" onclick="setHome(this, window.location)">Set as Homepage</a>
                 </div>
             </div>
@@ -200,6 +196,7 @@ layout: none
         var search=function(site,env){var searchId=env==='pc'?'search-pc':'search-mobile';var baseURL={google:'https://www.google.com/search?q=',baidu:'https://www.baidu.com/s?wd=',bing:'https://www.bing.com/search?q=',wolframalpha:'https://www.wolframalpha.com/input/?i=',wolframalpha_mob:'https://m.wolframalpha.com/input/?i='};window.open(baseURL[site]+encodeURIComponent(document.getElementById(searchId).value))};
         document.getElementById("search-form-pc").onsubmit=function(e){e.preventDefault();search('google','pc')};
         document.getElementById("search-form-mobile").onsubmit=function(e){e.preventDefault();search('bing','mobile')};
+        document.getElementById("find-form-pc").onsubmit=function(e){e.preventDefault();};
         document.addEventListener('DOMContentLoaded',function(){const searchInput=document.getElementById('find-in-page-input');const noResultsMessage=document.getElementById('no-results-message');if(!searchInput)return;const mainBlocks=document.querySelectorAll('.main-block');searchInput.addEventListener('input',function(){const searchTerm=this.value.toLowerCase().trim();let totalVisibleItems=0;mainBlocks.forEach(function(block){const items=block.querySelectorAll('.searchable-item');let hasVisibleItems=false;items.forEach(function(item){const keywords=item.getAttribute('data-keywords');if(searchTerm===''||keywords.includes(searchTerm)){item.style.display='block';hasVisibleItems=true;totalVisibleItems++}else{item.style.display='none'}});if(hasVisibleItems||searchTerm===''){block.style.display='block'}else{block.style.display='none'}});if(searchTerm!==''&&totalVisibleItems===0){noResultsMessage.style.display='block'}else{noResultsMessage.style.display='none'}})});
     </script>
 </html>


### PR DESCRIPTION
## Summary

Fixes the Find-in-page box layout (the CLAUDE.md "Next Task") and resolves a couple of open issues.

### Find box layout (main task)
- The Find input and Find button now sit on the **same line, stuck together like a Google search box**, instead of wrapping onto separate lines.
- Replaced the fragile float/absolute markup with a small flex layout (`.u_find-form`, `.u_find-input`, `.u_find-btn`) and restored the visible **Find** button (previously commented out).
- Added a submit handler so pressing Enter / clicking Find no longer reloads the page (live keyword filtering already runs on `input`).

### Issue #13 — help/issues button
- Added an **Issues** link to the top navigation pointing at the new-issue page, so users can report problems directly.

### Issue #15 — add/check AI services
- Added the UT **AI Services** submission link (`https://aiservices.austin.utexas.edu/submit/`) to the existing *UT AI* section in `_data/links.yml`, following the same entry pattern.

### Not addressed
- Issue #14 (add the JSG front desk email into the JSG guide) — the actual front-desk email address wasn't provided, so I did not add a placeholder to a live student resource page. Happy to add it once the address is confirmed.

## Verification
Compiled the SCSS with dart-sass and rendered the nav statically in Chromium to confirm the input + Find button align on one line and the Issues link appears in the nav.

## Files changed
- `index.html` — Find box markup, Issues nav link, find-form submit handler
- `_sass/nav.scss` — `.u_find-*` styles
- `_data/links.yml` — AI Services entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAHNjVMAAHbACR2mAGQsZj)_