### PR TITLE
Add EPS/JSG front desk contact info to JSG guide

### DIFF
--- a/guides/jsg.html
+++ b/guides/jsg.html
@@ -66,6 +66,19 @@ layout: none
                 </a>
             </div>
 
+            <div class="step">
+                <h3>Contact Info Quick Reference</h3>
+                <p>Department of Earth and Planetary Sciences (EPS) key contacts:</p>
+                <ul>
+                    <li><strong>EPS Front Office:</strong> <a href="mailto:EPSoffice@jsg.utexas.edu">EPSoffice@jsg.utexas.edu</a> &mdash; key requests, JSG room requests, information requests, etc.</li>
+                    <li><strong>JSG Advising:</strong> <a href="mailto:Geo_Advising@jsg.utexas.edu">Geo_Advising@jsg.utexas.edu</a></li>
+                    <li><strong>JSG Business Services Office (BSO):</strong> <a href="mailto:geobus@jsg.utexas.edu">geobus@jsg.utexas.edu</a></li>
+                </ul>
+                <a href="https://www.jsg.utexas.edu/people/jsg-community/" class="button" target="_blank" rel="noopener noreferrer">
+                    JSG Community Resources
+                </a>
+            </div>
+
             <p style="margin-top: 20px;">
                 <a href="/">&larr; Back to Navigation</a>
             </p>


### PR DESCRIPTION
## Summary

Resolves issue #14 — adds the JSG/EPS front desk contact info to the JSG guide.

Adds a **Contact Info Quick Reference** section to `guides/jsg.html` for the Department of Earth and Planetary Sciences (EPS):

- **EPS Front Office:** EPSoffice@jsg.utexas.edu — key requests, JSG room requests, information requests, etc.
- **JSG Advising:** Geo_Advising@jsg.utexas.edu
- **JSG Business Services Office (BSO):** geobus@jsg.utexas.edu
- Link to **JSG Community Resources** (jsg.utexas.edu/people/jsg-community/)

Emails are `mailto:` links so they're clickable, matching the existing guide styling.

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAHNjVMAAHbACR2mAGQsZj)_