### PR TITLE
Add contact methods dialog and mobile find-in-page box

### DIFF
--- a/_sass/nav.scss
+++ b/_sass/nav.scss
@@ -118,6 +118,89 @@
   }
 }
 
+/* Contact trigger button in nav */
+.u_nav-contact-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  font-family: inherit;
+  padding: 0;
+}
+
+/* Contact dialog */
+dialog#contact-dialog {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 0;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+}
+dialog#contact-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+.dialog-close {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #777;
+  cursor: pointer;
+  line-height: 1;
+}
+#contact-content {
+  padding: 24px;
+}
+.detail-source {
+  font-size: 12px;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.detail-title.contact-title {
+  margin: 6px 0 10px;
+  font-size: 20px;
+  color: #333;
+}
+.detail-summary {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 16px;
+}
+.contact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.contact-list > li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid #eee;
+}
+.contact-list > li:last-child {
+  border-bottom: 0;
+}
+.contact-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #444;
+}
+.contact-label .brand-icon {
+  width: 20px;
+  height: 20px;
+  fill: #337ab7;
+}
+.contact-value {
+  color: #337ab7;
+  font-size: 14px;
+}
+
 /* 移动端搜索框组 */
 .um_nav-input-group {
   display: none;
@@ -158,5 +241,20 @@
   }
   .um_nav-btn:last-child {
     border-radius: 0 3px 3px 0;
+  }
+  /* Mobile find-in-page form */
+  .um_find-form {
+    display: flex;
+    align-items: stretch;
+    clear: both;
+    padding-top: 10px;
+  }
+  .um_find-form .um_find-input {
+    width: 130px;
+  }
+  .um_find-form .um_nav-btn.um_find-btn {
+    width: 70px;
+    font-weight: bold;
+    background-color: #f8f9fa;
   }
 }

--- a/index.html
+++ b/index.html
@@ -108,6 +108,14 @@ layout: none
                     <div class="um_nav-btn" onclick="search('google', 'mobile')">Google</div>
                     <div class="um_nav-btn" onclick="search('bing', 'mobile')">Bing</div>
                     <div class="um_nav-btn" onclick="search('wolframalpha_mob', 'mobile')">Wolfram</div>
+                    <div class="clearfix"></div>
+                    <form id="find-form-mobile" class="um_find-form">
+                        <input class="um_nav-input um_find-input" id="find-in-page-input-mobile" placeholder="Find in page...">
+                        <button type="submit" class="um_nav-btn um_find-btn">Find</button>
+                    </form>
+                    <div id="no-results-message-mobile" class="no-results-nav" style="display: none;">
+                        No results found. Try a different search term.
+                    </div>
                 </div>
                 <div class="u_nav-input-group u_find-group" style="position: absolute; left: 41%; transform: translateX(-50%); top: 10px; margin-left: 150px; z-index: 1;">
                     <form id="find-form-pc" class="u_find-form">
@@ -123,6 +131,7 @@ layout: none
                         <a href="https://github.com/ut01/ut01.github.io/fork" class="u_nav-link">Fork ut01</a>
                     </div>
                     <a href="https://github.com/ut01/ut01.github.io/issues/new" class="u_nav-link" target="_blank" rel="noopener noreferrer">Issues</a>
+                    <button type="button" class="u_nav-link u_nav-contact-btn" id="contact-trigger" aria-haspopup="dialog">Contact</button>
                     <a href="#" class="u_nav-link" onclick="setHome(this, window.location)">Set as Homepage</a>
                 </div>
             </div>
@@ -187,6 +196,10 @@ layout: none
                 This is a fork of <a href="https://ustc.life/">USTC Navigation</a> provided by <a href="https://0x01.me/">Hypercube</a> and <a href="https://github.com/SmartHypercube/ustclife/graphs/contributors">contributors</a>, source code is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>.
                 </div>
         </div>
+        <dialog id="contact-dialog" aria-labelledby="contact-title">
+            <button class="dialog-close" id="contact-close" type="button" aria-label="Close contact options">×</button>
+            <div id="contact-content"></div>
+        </dialog>
         <!-- https://clustrmaps.com/profile/1c6il/widget/customize -->
         <!-- <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/map_v2.js?cl=a5a0a0&w=a&t=tt&d=fQvKmZbPMctrjCs0jp8rDLqKYPwmQtmFVMiOSl9YUsE&co=f1f1f1&cmo=bc3a3a&cmn=1fd31f&ct=808080'></script> -->
         <script type='text/javascript' id='clustrmaps' src='//cdn.clustrmaps.com/counter_v2.js?cl=ffffff&w=a&t=n&d=YOUR_ID'></script>
@@ -197,6 +210,21 @@ layout: none
         document.getElementById("search-form-pc").onsubmit=function(e){e.preventDefault();search('google','pc')};
         document.getElementById("search-form-mobile").onsubmit=function(e){e.preventDefault();search('bing','mobile')};
         document.getElementById("find-form-pc").onsubmit=function(e){e.preventDefault();};
-        document.addEventListener('DOMContentLoaded',function(){const searchInput=document.getElementById('find-in-page-input');const noResultsMessage=document.getElementById('no-results-message');if(!searchInput)return;const mainBlocks=document.querySelectorAll('.main-block');searchInput.addEventListener('input',function(){const searchTerm=this.value.toLowerCase().trim();let totalVisibleItems=0;mainBlocks.forEach(function(block){const items=block.querySelectorAll('.searchable-item');let hasVisibleItems=false;items.forEach(function(item){const keywords=item.getAttribute('data-keywords');if(searchTerm===''||keywords.includes(searchTerm)){item.style.display='block';hasVisibleItems=true;totalVisibleItems++}else{item.style.display='none'}});if(hasVisibleItems||searchTerm===''){block.style.display='block'}else{block.style.display='none'}});if(searchTerm!==''&&totalVisibleItems===0){noResultsMessage.style.display='block'}else{noResultsMessage.style.display='none'}})});
+        document.getElementById("find-form-mobile").onsubmit=function(e){e.preventDefault();};
+        var setupFind=function(inputId,msgId){var searchInput=document.getElementById(inputId);if(!searchInput)return;var noResultsMessage=document.getElementById(msgId);var mainBlocks=document.querySelectorAll('.main-block');var apply=function(){var searchTerm=searchInput.value.toLowerCase().trim();var totalVisibleItems=0;mainBlocks.forEach(function(block){var items=block.querySelectorAll('.searchable-item');var hasVisibleItems=false;items.forEach(function(item){var keywords=item.getAttribute('data-keywords');if(searchTerm===''||keywords.indexOf(searchTerm)!==-1){item.style.display='block';hasVisibleItems=true;totalVisibleItems++}else{item.style.display='none'}});if(hasVisibleItems||searchTerm===''){block.style.display='block'}else{block.style.display='none'}});if(searchTerm!==''&&totalVisibleItems===0){noResultsMessage.style.display='block'}else{noResultsMessage.style.display='none'}};searchInput.addEventListener('input',apply);};
+        document.addEventListener('DOMContentLoaded',function(){setupFind('find-in-page-input','no-results-message');setupFind('find-in-page-input-mobile','no-results-message-mobile');});
+        document.getElementById("contact-trigger").addEventListener('click',openContact);
+        document.getElementById("contact-close").addEventListener('click',function(){document.getElementById("contact-dialog").close();});
+        document.getElementById("contact-dialog").addEventListener('click',function(e){if(e.target===this)this.close();});
+        function openContact(){var content=document.getElementById("contact-content");content.innerHTML=''+
+            '<p class="detail-source">ut01 Navigation</p>'+
+            '<h2 class="detail-title contact-title" id="contact-title">Get in touch</h2>'+
+            '<p class="detail-summary">Found a broken link or want to add a resource? Reach out any time.</p>'+
+            '<ul class="contact-list">'+
+            '<li><span class="contact-label">'+contactIcon('email')+'<strong>Email</strong></span><a class="contact-value" href="mailto:ktwu01@gmail.com">ktwu01@gmail.com</a></li>'+
+            '<li><span class="contact-label">'+contactIcon('wechat')+'<strong>WeChat</strong></span><span class="contact-value">ID ktwu001</span></li>'+
+            '<li><span class="contact-label">'+contactIcon('discord')+'<strong>Discord</strong></span><span class="contact-value">ID ktwu01</span></li>'+
+            '</ul>';document.getElementById("contact-dialog").showModal();}
+        function contactIcon(name){var paths={email:'M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm9 6.9L4.2 6h15.6L12 11.9Zm-8 6.6V8.9l8 5.9 8-5.9v9.6H4Z',wechat:'M8.691 2.188C3.891 2.188 0 5.476 0 9.53c0 2.212 1.17 4.203 3.002 5.55a.59.59 0 0 1 .213.665l-.39 1.48c-.019.07-.048.141-.048.213 0 .163.13.295.29.295a.326.326 0 0 0 .167-.054l1.903-1.114a.864.864 0 0 1 .717-.098 10.16 10.16 0 0 0 2.837.403c.276 0 .543-.027.811-.05a6.127 6.127 0 0 1-.253-1.72c0-3.571 3.437-6.467 7.678-6.467.233 0 .463.013.694.031C17.02 4.792 13.205 2.188 8.69 2.188Zm-2.6 4.408c.654 0 1.184.517 1.184 1.154 0 .637-.53 1.154-1.184 1.154-.654 0-1.184-.517-1.184-1.154 0-.637.53-1.154 1.184-1.154Zm5.51 0c.654 0 1.184.517 1.184 1.154 0 .637-.53 1.154-1.184 1.154-.654 0-1.184-.517-1.184-1.154 0-.637.53-1.154 1.184-1.154Zm7.835 3.124c-3.858 0-6.984 2.667-6.984 5.957 0 3.29 3.126 5.957 6.984 5.957.848 0 1.663-.146 2.418-.408a.622.622 0 0 1 .516.07l1.371.802a.235.235 0 0 0 .12.039.213.213 0 0 0 .208-.213c0-.052-.02-.102-.035-.153l-.28-1.067a.426.426 0 0 1 .153-.479c1.359-1.111 2.2-2.707 2.2-4.548 0-3.29-3.126-5.957-6.984-5.957Zm-3.865 3.594c.55 0 .996.435.996.971 0 .537-.446.972-.996.972-.55 0-.996-.435-.996-.972 0-.536.446-.971.996-.971Zm7.729 0c.55 0 .996.435.996.971 0 .537-.446.972-.996.972-.55 0-.996-.435-.996-.972 0-.536.446-.971.996-.971Z',discord:'M20.317 4.3698a19.7913 19.7913 0 0 0-4.8851-1.5152.0741.0741 0 0 0-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 0 0-.0785-.037 19.7363 19.7363 0 0 0-4.8852 1.515.0699.0699 0 0 0-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 0 0 .0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 0 0 .0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 0 0-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 0 1-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 0 1 .0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 0 1 .0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 0 1-.0066.1276 12.2986 12.2986 0 0 1-1.873.8914.0766.0766 0 0 0-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 0 0 .0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 0 0 .0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 0 0-.0312-.0286ZM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0957 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189Zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0957 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z'};var s=document.createElementNS('http://www.w3.org/2000/svg','svg');s.setAttribute('viewBox','0 0 24 24');s.setAttribute('class','brand-icon');s.setAttribute('aria-hidden','true');var p=document.createElementNS('http://www.w3.org/2000/svg','path');p.setAttribute('d',paths[name]);s.appendChild(p);return s.outerHTML;};
     </script>
 </html>


### PR DESCRIPTION
Resolves #34 (add my contact methods at top right of the page) and #20 (this cannot be shown on iphone chrome).

- #34: Added a Contact button in the top-right nav opening a dialog with email (ktwu01@gmail.com), WeChat (ktwu001), and Discord (ktwu01) contact methods, mirroring the benchmark-radar contact sheet.
- #20: Added a find-in-page box to the mobile nav (under 1000px) so iPhone Chrome users can search within the page; previously the mobile view only offered Google/Bing/Wolfram outbound search.