### PR TITLE
Add mobile-reachable top-right nav links (Fixes #36)

### DIFF
--- a/_sass/nav.scss
+++ b/_sass/nav.scss
@@ -257,4 +257,15 @@ dialog#contact-dialog::backdrop {
     font-weight: bold;
     background-color: #f8f9fa;
   }
+  .um_nav-links {
+    clear: both;
+    padding: 10px 15px 4px;
+    font-size: 13px;
+    > a,
+    > button {
+      color: #777;
+      margin-right: 18px;
+      white-space: nowrap;
+    }
+  }
 }

--- a/index.html
+++ b/index.html
@@ -116,6 +116,12 @@ layout: none
                     <div id="no-results-message-mobile" class="no-results-nav" style="display: none;">
                         No results found. Try a different search term.
                     </div>
+                    <div class="um_nav-links clearfix">
+                        <a href="https://github.com/ut01/ut01.github.io/fork" class="u_nav-link">Fork ut01</a>
+                        <a href="https://github.com/ut01/ut01.github.io/issues/new" class="u_nav-link" target="_blank" rel="noopener noreferrer">Issues</a>
+                        <button type="button" class="u_nav-link u_nav-contact-btn" id="contact-trigger-mobile" aria-haspopup="dialog">Contact</button>
+                        <a href="#" class="u_nav-link" onclick="setHome(this, window.location)">Set as Homepage</a>
+                    </div>
                 </div>
                 <div class="u_nav-input-group u_find-group" style="position: absolute; left: 41%; transform: translateX(-50%); top: 10px; margin-left: 150px; z-index: 1;">
                     <form id="find-form-pc" class="u_find-form">
@@ -213,7 +219,8 @@ layout: none
         document.getElementById("find-form-mobile").onsubmit=function(e){e.preventDefault();};
         var setupFind=function(inputId,msgId){var searchInput=document.getElementById(inputId);if(!searchInput)return;var noResultsMessage=document.getElementById(msgId);var mainBlocks=document.querySelectorAll('.main-block');var apply=function(){var searchTerm=searchInput.value.toLowerCase().trim();var totalVisibleItems=0;mainBlocks.forEach(function(block){var items=block.querySelectorAll('.searchable-item');var hasVisibleItems=false;items.forEach(function(item){var keywords=item.getAttribute('data-keywords');if(searchTerm===''||keywords.indexOf(searchTerm)!==-1){item.style.display='block';hasVisibleItems=true;totalVisibleItems++}else{item.style.display='none'}});if(hasVisibleItems||searchTerm===''){block.style.display='block'}else{block.style.display='none'}});if(searchTerm!==''&&totalVisibleItems===0){noResultsMessage.style.display='block'}else{noResultsMessage.style.display='none'}};searchInput.addEventListener('input',apply);};
         document.addEventListener('DOMContentLoaded',function(){setupFind('find-in-page-input','no-results-message');setupFind('find-in-page-input-mobile','no-results-message-mobile');});
-        document.getElementById("contact-trigger").addEventListener('click',openContact);
+        var contactTrigger=document.getElementById("contact-trigger");if(contactTrigger)contactTrigger.addEventListener('click',openContact);
+        var contactTriggerMobile=document.getElementById("contact-trigger-mobile");if(contactTriggerMobile)contactTriggerMobile.addEventListener('click',openContact);
         document.getElementById("contact-close").addEventListener('click',function(){document.getElementById("contact-dialog").close();});
         document.getElementById("contact-dialog").addEventListener('click',function(e){if(e.target===this)this.close();});
         function openContact(){var content=document.getElementById("contact-content");content.innerHTML=''+


### PR DESCRIPTION
Fixes #36

The top-right nav links (Fork ut01, Issues, Contact, Set as Homepage) were hidden below 1000px width, so mobile users could not reach them.

Added a compact `.um_nav-links` row inside the mobile nav group with all four links, and bound the mobile Contact button to the contact dialog.